### PR TITLE
Fix pager, if no enough results returns

### DIFF
--- a/spannercli/main.py
+++ b/spannercli/main.py
@@ -292,7 +292,7 @@ class SpannerCli(object):
             formatted = self.formatter.format_output(
                 result.data, result.header, **opt)
             if self.with_pager:
-                click.echo_via_pager(formatted)
+                click.echo_via_pager("\n".join(list(formatted)))
             else:
                 for n in formatted:
                     click.secho(n)


### PR DESCRIPTION
Fix for this case
```
> select 1;
+---+|   |+---+| 1 |+---+

rows_returned: 1, scanned: 0, elapsed_time: 1.34 msecs, cpu_time:0.51
msecs
```