### PR TITLE
Fix query if endswith `\G `

### DIFF
--- a/spannercli/main.py
+++ b/spannercli/main.py
@@ -136,7 +136,7 @@ class SpannerCli(object):
 
     def read_query(self, sql) -> structures.ResultContainer:
         meta = {}
-        if sql.endswith('\\G'):
+        if sql.strip().endswith('\\G'):
             meta['format'] = 'vertical'
             sql = sql[:-2]
 


### PR DESCRIPTION
```
> select 1 \G
DEBUG:spanner-cli:QUERY: select 1 \G

Syntax error: Illegal input character "\\" [at 1:10]
select 1 \G
```