### PR TITLE
Fix the job for actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         TWINE_USERNAME: __token__
         #TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-      run: sed -i "s/__DEV__/${{ github.event.release.tag_name }}/g" spannercli/__init__.py
       run: |
+        sed -i "s/__DEV__/${{ github.event.release.tag_name }}/g" spannercli/__init__.py
         python setup.py sdist bdist_wheel
         twine --repository testpypi upload dist/*


### PR DESCRIPTION
```
Invalid workflow file
The workflow is not valid. .github/workflows/publish.yml (Line: 26, Col: 7): 'run' is already defined
```