### PR TITLE
Fix CI, ModuleNotFoundError importlib_metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pipenv
+        python -m pip install importlib_metadata
         pipenv install --dev
     - name: Lint with pylint
       run: |


### PR DESCRIPTION
Fix
```
  File "/home/runner/.local/share/virtualenvs/spanner-cli-NiVXAW-d/lib/python3.7/site-packages/pluggy/__init__.py", line 16, in <module>
    from .manager import PluginManager, PluginValidationError
  File "/home/runner/.local/share/virtualenvs/spanner-cli-NiVXAW-d/lib/python3.7/site-packages/pluggy/manager.py", line 11, in <module>
    import importlib_metadata
ModuleNotFoundError: No module named 'importlib_metadata'
```

according to
https://github.com/pytest-dev/pytest/issues/7114