### PR TITLE
Add feature: pygment style from env to use it

### DIFF
--- a/spannercli/config/__init__.py
+++ b/spannercli/config/__init__.py
@@ -1,4 +1,7 @@
+import os
+
 from google.oauth2 import service_account
+import pygments.styles
 
 from .constant import Constants
 from .env import EnvironmentVariables
@@ -8,6 +11,15 @@ def resolve_credential(credential):
     if credential is not None:
         return service_account.Credentials.from_service_account_file(credential)
     return None
+
+
+def get_pygment_style():
+    e = os.getenv(EnvironmentVariables.PYGMENT_STYLE)
+    if e is None:
+        return Constants.PYGMENT_STYLE
+    if e not in pygments.styles.STYLE_MAP.keys():
+        return Constants.PYGMENT_STYLE
+    return e
 
 
 __all__ = [

--- a/spannercli/config/env.py
+++ b/spannercli/config/env.py
@@ -45,3 +45,9 @@ class EnvironmentVariables(object):
     """
     Options which are passed to less automatically. default is "-RXF" defined as Constants.LESS_FLAG
     """
+
+    PYGMENT_STYLE = "PYGMENT_STYLE"
+    """
+    The builtin styles of PYGMENT. default is Constants.PYGMENT_STYLE
+    see https://pygments.org/docs/styles/
+    """

--- a/spannercli/main.py
+++ b/spannercli/main.py
@@ -66,7 +66,7 @@ class SpannerCli(object):
             message=self.prompt_message,
             lexer=PygmentsLexer(lexer.SpannerLexer),
             completer=DynamicCompleter(lambda: self.completer),
-            style=style_from_pygments_cls(get_style_by_name(config.Constants.PYGMENT_STYLE)),
+            style=style_from_pygments_cls(get_style_by_name(config.get_pygment_style())),
             history=self.history,
             auto_suggest=AutoSuggestFromHistory(),
             input_processors=[ConditionalProcessor(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+from spannercli import config
+
+
+def test_get_pygment_style_accept(monkeypatch):
+    monkeypatch.setenv(config.EnvironmentVariables.PYGMENT_STYLE, "inkpot")
+    ret = config.get_pygment_style()
+    assert ret == 'inkpot'
+
+
+def test_get_pygment_style_default():
+    ret = config.get_pygment_style()
+    assert ret == config.Constants.PYGMENT_STYLE
+
+
+def test_get_pygment_style_fallback(monkeypatch):
+    monkeypatch.setenv(config.EnvironmentVariables.PYGMENT_STYLE, "not_supported")
+    ret = config.get_pygment_style()
+    assert ret == config.Constants.PYGMENT_STYLE


### PR DESCRIPTION
Add feature, accept pygment builtin style name from EnvironmentVariables to configure it.

`PYGMENT_STYLE=inkpot  spanner-cli`

https://pygments.org/docs/styles/#builtin-styles